### PR TITLE
Introduce line-bot-api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
 
+  gem 'dotenv-rails'
+
   # rubocop
   gem 'rubocop', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'bootsnap', require: false
 
 gem 'annotate'
 
+gem 'line-bot-api'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       reline (>= 0.3.6)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    line-bot-api (1.28.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -198,6 +199,7 @@ DEPENDENCIES
   annotate
   bootsnap
   debug
+  line-bot-api
   puma (~> 5.0)
   rails (~> 7.0.7, >= 7.0.7.2)
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,10 @@ GEM
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     globalid (1.2.0)
       activesupport (>= 6.1)
@@ -199,6 +203,7 @@ DEPENDENCIES
   annotate
   bootsnap
   debug
+  dotenv-rails
   line-bot-api
   puma (~> 5.0)
   rails (~> 7.0.7, >= 7.0.7.2)

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,0 +1,41 @@
+class LinebotController < ApplicationController
+  require 'line/bot'
+
+  def callback
+    body = request.body.read
+    signature = request.env['HTTP_X_LINE_SIGNATURE']
+
+    # LINEからのリクエストの検証
+    unless client.validate_signature(body, signature)
+      return render plain: 'Bad Request', status: 400
+    end
+
+    events = client.parse_events_from(body)
+
+    # line-bot-apiで解析されたeventの処理。
+    # 一旦message eventのみ対応。
+    events.each do |event|
+      if event.is_a?(Line::Bot::Event::Message)
+        parsed_message = MessageParser.parse(event.message['text'])
+        reply_text = MessageHandler.perform(parsed_message)
+
+        message = {
+          type: 'text',
+          text: reply_text
+        }
+        client.reply_message(event['replyToken'], message)
+      end
+    end
+
+    head :ok
+  end
+
+  private
+
+  def client
+    @client ||= Line::Bot::Client.new do |config|
+      config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+      config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+    end
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -9,4 +9,6 @@
 #
 class Group < ApplicationRecord
   has_many :users
+
+  validates :name, presence: true, length: { maximum: 10 }
 end

--- a/app/service/message_handler.rb
+++ b/app/service/message_handler.rb
@@ -1,0 +1,9 @@
+class MessageHandler
+  class << self
+    # messageを受け取り、適切な処理に振り分け、replyを返す
+    def perform(message)
+      # 一旦動作確認のため、messageをそのまま返す
+      return message
+    end
+  end
+end

--- a/app/service/message_parser.rb
+++ b/app/service/message_parser.rb
@@ -1,0 +1,9 @@
+class MessageParser
+  class << self
+    # messageを受け取り、parsed_messageを返す。
+    def parse(message)
+      # 動作確認のため、一旦messageをそのまま返す
+      return message
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,4 +63,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.hosts << '.ngrok-free.app'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  post '/callback', to: 'linebot#callback'
 end


### PR DESCRIPTION
ひとまず、LINE Messaging APIが使えるようにしてみる。

gem 'line-bot-api'を追加し、linebot_controllerを定義。

[root_path]/callbackのURLをLINE Messaging APIの設定部分のwebhook_urlに設定。

ngrokでhttps化したlocalhost:3000のurlに上記のwebhook_urlのpostリクエストが飛ぶようにして、一旦オウム返しができるかのテストを実施。

ひとまず動作確認できた。次はラズパイの環境のセットアップをし、一旦オウム返しのバージョンのアプリケーションをデプロイ。

それも問題なく終了したら、MessageParserやMessageHandlerの実装を進め、各種処理を実装していく予定。