### PR TITLE
🐛 fix: Fix category exists check

### DIFF
--- a/app/services/message_parser/show_message_parser.rb
+++ b/app/services/message_parser/show_message_parser.rb
@@ -23,7 +23,7 @@ module MessageParser
         category = lines[1]
 
         return error_message(ERROR_TYPE[:MONTH]) unless month_specification_valid?(lines.first)
-        return error_message(ERROR_TYPE[:CATEGORY]) if category && !Category.find_by(name: category)
+        return error_message(ERROR_TYPE[:CATEGORY]) if category_not_found?(category)
 
         # '月の合計を返す'
         GetMonthlyTotalUsecase.perform(user:, period:, category:)
@@ -87,6 +87,11 @@ module MessageParser
         ERROR
 
         error_message.chomp
+      end
+
+      def category_not_found?(category)
+        # 期間のみ入力されて費目の指定がない場合、費目の部分に合計と書かれた場合は除外
+        (category || category != '合計') && !Category.find_by(name: category)
       end
 
       def category_not_found_message

--- a/app/usecases/get_monthly_total_usecase.rb
+++ b/app/usecases/get_monthly_total_usecase.rb
@@ -2,7 +2,7 @@ class GetMonthlyTotalUsecase
   class << self
     def perform(user:, period:, category: nil)
       # group機能は未実装なため、一旦user自体の家計簿データの合計を返す。
-      total = if category
+      total = if category && category != '合計'
                 ExpenseRecord.eager_load(:category)
                              .expense
                              .where(user:, transaction_date: period)


### PR DESCRIPTION
確認モードで

```
今月
合計
```

と入力された場合に、「合計」という費目は存在しません、というようなエラーメッセージを返してしまっていた。

合計と入力された場合は、指定された期間の合計を返す。