### PR TITLE
Add SoftDelete for ExpenseRecord, and call this usecase if a cancel message is received

### DIFF
--- a/app/models/expense_record.rb
+++ b/app/models/expense_record.rb
@@ -32,6 +32,7 @@ class ExpenseRecord < ApplicationRecord
     income: 1
   }
 
+  scope :active, -> { where(is_disabled: false) }
   scope :expense, -> { where(expense_type: :expense) }
   scope :income, -> { where(expense_type: :income) }
 end

--- a/app/models/expense_record.rb
+++ b/app/models/expense_record.rb
@@ -5,6 +5,7 @@
 #  id               :integer          not null, primary key
 #  amount           :integer          not null
 #  expense_type     :integer          default("expense"), not null
+#  is_disabled      :boolean          default(FALSE), not null
 #  memorandum       :text
 #  transaction_date :datetime         not null
 #  created_at       :datetime         not null

--- a/app/services/message_parser/input_message_parser.rb
+++ b/app/services/message_parser/input_message_parser.rb
@@ -44,6 +44,9 @@ module MessageParser
       end
 
       def perform_expense_or_income(message:, user:)
+        # とりけし のようなメッセージが出た場合は、直近の家計簿データを論理削除する。
+        return SoftDeleteLatestExpenseRecordUsecase.new(user).perform if CANCEL_WORDS.any? { |cancel_word| message.start_with?(cancel_word) }
+
         expense_type = user.talk_mode.to_sym == :income_input_mode ? :income : :expense
         # parsed_message_hash: { category: category, amount: amount, memorandum: memorandum, transaction_date: transaction_date }
         parsed_message_hash = parse_message(message)

--- a/app/usecases/create_expense_record_usecase.rb
+++ b/app/usecases/create_expense_record_usecase.rb
@@ -27,6 +27,8 @@ class CreateExpenseRecordUsecase
             #{expense_type == :expense ? '支出' : '収入'}データを続けて入力する場合は、このまま続けて入力できます。
 
             #{expense_type == :expense ? '収入' : '支出'}データを入力する場合は、#{expense_type == :expense ? '収入' : '支出'}データ入力のメニューをタップしてください。
+
+            入力したデータを取り消したい場合は、「とりけし」と入力してください。
           MESSAGE
 
           response_message.chomp

--- a/app/usecases/get_monthly_total_usecase.rb
+++ b/app/usecases/get_monthly_total_usecase.rb
@@ -4,13 +4,14 @@ class GetMonthlyTotalUsecase
       # group機能は未実装なため、一旦user自体の家計簿データの合計を返す。
       total = if category && category != '合計'
                 ExpenseRecord.eager_load(:category)
+                             .active
                              .expense
                              .where(user:, transaction_date: period)
                              .where(categories: { name: category })
                              .sum(:amount)
               else
                 # 費目の指定がない場合は、userのExpenseRecordsの合計を返す
-                user.expense_records.expense.where(transaction_date: period).sum(:amount)
+                user.expense_records.active.expense.where(transaction_date: period).sum(:amount)
               end
       "#{total}円ナリ"
     end

--- a/app/usecases/soft_delete_latest_expense_record_usecase.rb
+++ b/app/usecases/soft_delete_latest_expense_record_usecase.rb
@@ -5,8 +5,19 @@ class SoftDeleteLatestExpenseRecordUsecase
   end
 
   def perform
-    p @latest_expense_record
     @latest_expense_record.update(is_disabled: true)
-    p @latest_expense_record
+
+    response_message = <<~MESSAGE
+      以下の家計簿データを取り消しました💡
+
+      費目: #{@latest_expense_record.category.name}
+      金額: #{@latest_expense_record.amount}
+      備考: #{@latest_expense_record.memorandum.present? ? @latest_expense_record.memorandum : ''}
+      日付: #{@latest_expense_record.transaction_date.to_date}
+    MESSAGE
+
+    response_message.chomp
+  rescue ActiveRecord::RecordInvalid => e
+    e.message
   end
 end

--- a/app/usecases/soft_delete_latest_expense_record_usecase.rb
+++ b/app/usecases/soft_delete_latest_expense_record_usecase.rb
@@ -10,4 +10,3 @@ class SoftDeleteLatestExpenseRecordUsecase
     p @latest_expense_record
   end
 end
-

--- a/app/usecases/soft_delete_latest_expense_record_usecase.rb
+++ b/app/usecases/soft_delete_latest_expense_record_usecase.rb
@@ -1,0 +1,13 @@
+class SoftDeleteLatestExpenseRecordUsecase
+  def initialize(user)
+    @user = user
+    @latest_expense_record = user.expense_records.last
+  end
+
+  def perform
+    p @latest_expense_record
+    @latest_expense_record.update(is_disabled: true)
+    p @latest_expense_record
+  end
+end
+

--- a/db/migrate/20240212063914_add_is_disabled_to_expense_records.rb
+++ b/db/migrate/20240212063914_add_is_disabled_to_expense_records.rb
@@ -1,0 +1,5 @@
+class AddIsDisabledToExpenseRecords < ActiveRecord::Migration[7.0]
+  def change
+    add_column :expense_records, :is_disabled, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_12_143935) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_12_063914) do
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -26,6 +26,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_12_143935) do
     t.text "memorandum"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_disabled", default: false, null: false
     t.index ["category_id"], name: "index_expense_records_on_category_id"
     t.index ["user_id"], name: "index_expense_records_on_user_id"
   end

--- a/spec/factories/expense_records.rb
+++ b/spec/factories/expense_records.rb
@@ -5,6 +5,7 @@
 #  id               :integer          not null, primary key
 #  amount           :integer          not null
 #  expense_type     :integer          default("expense"), not null
+#  is_disabled      :boolean          default(FALSE), not null
 #  memorandum       :text
 #  transaction_date :datetime         not null
 #  created_at       :datetime         not null

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,6 +22,6 @@
 FactoryBot.define do
   factory :user do
     name { 'username' }
-    line_id { 'xxxxxxxxxx' }
+    line_id { SecureRandom.uuid }
   end
 end

--- a/spec/services/message_parser/input_message_parser_spec.rb
+++ b/spec/services/message_parser/input_message_parser_spec.rb
@@ -158,6 +158,43 @@ RSpec.describe MessageParser::InputMessageParser do
         end
       end
 
+      context '入力したデータを取り消す場合' do
+        let(:message) { 'とりけし' }
+        let(:response_message) do
+          <<~MESSAGE
+            以下の家計簿データを取り消しました💡
+
+            費目: 食費
+            金額: 1500
+            備考: memorandum
+            日付: #{Time.zone.now.to_date}
+          MESSAGE
+        end
+
+        before do
+          # 論理削除されていない支出データを準備しておく
+          create(
+            :expense_record,
+            user:,
+            expense_type: :expense,
+            amount: 1500,
+            category: create(:category, name: '食費'),
+            transaction_date: Time.zone.today,
+            memorandum: 'memorandum',
+            is_disabled: false
+          )
+        end
+
+        it '最新の家計簿データが論理削除される' do
+          result
+          expect(user.expense_records.last.is_disabled).to be_truthy
+        end
+
+        it 'とりけし成功のメッセージが返却される' do
+          expect(result).to eq(response_message.chomp)
+        end
+      end
+
       context 'when expense_input message is invalid' do
         context 'when category is empty' do
           let(:message) { '' }
@@ -280,6 +317,43 @@ RSpec.describe MessageParser::InputMessageParser do
         end
 
         it 'succeeds in creating expense_record' do
+          expect(result).to eq(response_message.chomp)
+        end
+      end
+
+      context '入力したデータを取り消す場合' do
+        let(:message) { 'とりけし' }
+        let(:response_message) do
+          <<~MESSAGE
+            以下の家計簿データを取り消しました💡
+
+            費目: 給与
+            金額: 150000
+            備考: memorandum
+            日付: #{Time.zone.now.to_date}
+          MESSAGE
+        end
+
+        before do
+          # 論理削除されていない収入データを準備しておく
+          create(
+            :expense_record,
+            user:,
+            expense_type: :income,
+            amount: 150_000,
+            category: create(:category, name: '給与'),
+            transaction_date: Time.zone.today,
+            memorandum: 'memorandum',
+            is_disabled: false
+          )
+        end
+
+        it '最新の家計簿データが論理削除される' do
+          result
+          expect(user.expense_records.last.is_disabled).to be_truthy
+        end
+
+        it 'とりけし成功のメッセージが返却される' do
           expect(result).to eq(response_message.chomp)
         end
       end

--- a/spec/services/message_parser/input_message_parser_spec.rb
+++ b/spec/services/message_parser/input_message_parser_spec.rb
@@ -100,6 +100,8 @@ RSpec.describe MessageParser::InputMessageParser do
             支出データを続けて入力する場合は、このまま続けて入力できます。
 
             収入データを入力する場合は、収入データ入力のメニューをタップしてください。
+
+            入力したデータを取り消したい場合は、「とりけし」と入力してください。
           RESPONSE
         end
 
@@ -122,6 +124,8 @@ RSpec.describe MessageParser::InputMessageParser do
             支出データを続けて入力する場合は、このまま続けて入力できます。
 
             収入データを入力する場合は、収入データ入力のメニューをタップしてください。
+
+            入力したデータを取り消したい場合は、「とりけし」と入力してください。
           RESPONSE
         end
 
@@ -144,6 +148,8 @@ RSpec.describe MessageParser::InputMessageParser do
             支出データを続けて入力する場合は、このまま続けて入力できます。
 
             収入データを入力する場合は、収入データ入力のメニューをタップしてください。
+
+            入力したデータを取り消したい場合は、「とりけし」と入力してください。
           RESPONSE
         end
 
@@ -220,6 +226,8 @@ RSpec.describe MessageParser::InputMessageParser do
             収入データを続けて入力する場合は、このまま続けて入力できます。
 
             支出データを入力する場合は、支出データ入力のメニューをタップしてください。
+
+            入力したデータを取り消したい場合は、「とりけし」と入力してください。
           RESPONSE
         end
 
@@ -242,6 +250,8 @@ RSpec.describe MessageParser::InputMessageParser do
             収入データを続けて入力する場合は、このまま続けて入力できます。
 
             支出データを入力する場合は、支出データ入力のメニューをタップしてください。
+
+            入力したデータを取り消したい場合は、「とりけし」と入力してください。
           RESPONSE
         end
 
@@ -264,6 +274,8 @@ RSpec.describe MessageParser::InputMessageParser do
             収入データを続けて入力する場合は、このまま続けて入力できます。
 
             支出データを入力する場合は、支出データ入力のメニューをタップしてください。
+
+            入力したデータを取り消したい場合は、「とりけし」と入力してください。
           RESPONSE
         end
 

--- a/spec/usecases/create_expense_record_usecase_spec.rb
+++ b/spec/usecases/create_expense_record_usecase_spec.rb
@@ -15,9 +15,29 @@ RSpec.describe CreateExpenseRecordUsecase, type: :usecase do
           transaction_date: Time.zone.today.to_date.to_s
         }
       end
+      let(:return_message) do
+        <<~MESSAGE
+          支出データの登録に成功しました💡
+
+          費目: 食費
+          金額: 500
+          備考: memorandum
+          日付: #{Time.zone.today.to_date}
+
+          支出データを続けて入力する場合は、このまま続けて入力できます。
+
+          収入データを入力する場合は、収入データ入力のメニューをタップしてください。
+
+          入力したデータを取り消したい場合は、「とりけし」と入力してください。
+        MESSAGE
+      end
 
       it 'succeeds in creating a new expense record' do
         expect { usecase }.to change(ExpenseRecord, :count).from(0).to(1)
+      end
+
+      it '登録した支出データが記載されたメッセージが返される' do
+        expect(usecase).to eq(return_message.chomp)
       end
     end
 
@@ -31,9 +51,29 @@ RSpec.describe CreateExpenseRecordUsecase, type: :usecase do
           transaction_date: Time.zone.today.to_date.to_s
         }
       end
+      let(:return_message) do
+        <<~MESSAGE
+          収入データの登録に成功しました💡
+
+          費目: 給与
+          金額: 200000
+          備考: memorandum
+          日付: #{Time.zone.today.to_date}
+
+          収入データを続けて入力する場合は、このまま続けて入力できます。
+
+          支出データを入力する場合は、支出データ入力のメニューをタップしてください。
+
+          入力したデータを取り消したい場合は、「とりけし」と入力してください。
+        MESSAGE
+      end
 
       it 'succeeds in creating a new income record' do
         expect { usecase }.to change(ExpenseRecord, :count).from(0).to(1)
+      end
+
+      it '登録した収入データが記載されたメッセージが返される' do
+        expect(usecase).to eq(return_message.chomp)
       end
     end
 

--- a/spec/usecases/get_monthly_total_usecase_spec.rb
+++ b/spec/usecases/get_monthly_total_usecase_spec.rb
@@ -24,6 +24,27 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
       end
     end
 
+    context '論理削除されているレコードが存在する場合' do
+      let(:category_name) { nil }
+
+      before do
+        create(
+          :expense_record,
+          amount: 1000,
+          transaction_date: Time.zone.now,
+          user:,
+          category: create(:category, name: '電気代'),
+          is_disabled: true # 論理削除済み
+        )
+      end
+
+      it '論理削除済みの家計簿データの分は合計に加算されない' do
+        # このcontextで追加したexpense_recordの1000円分は加算されないので、
+        # 合計は1500円になる。
+        expect(usecase).to eq('1500円ナリ')
+      end
+    end
+
     context 'categoryが指定されている場合' do
       context '指定したcategory（食費）の家計簿データが存在する場合' do
         let(:category_name) { create(:category, name: '食費').name }
@@ -38,6 +59,25 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
 
         it '0円が返される' do
           expect(usecase).to eq('0円ナリ')
+        end
+      end
+
+      context '論理削除されているレコードが存在する場合' do
+        let(:category_name) { create(:category, name: '食費').name }
+
+        before do
+          create(
+            :expense_record,
+            amount: 1000,
+            transaction_date: Time.zone.now,
+            user:,
+            category: create(:category, name: '食費'),
+            is_disabled: true
+          )
+        end
+
+        it '今月の食費の合計金額が返される（論理削除済みの家計簿データ分は加算されない）' do
+          expect(usecase).to eq('1500円ナリ')
         end
       end
     end

--- a/spec/usecases/soft_delete_latest_expense_record_spec.rb
+++ b/spec/usecases/soft_delete_latest_expense_record_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe SoftDeleteLatestExpenseRecordUsecase, type: :usecase do
+  describe '.perform' do
+    let(:usecase) { described_class.new(user) }
+    let(:user) { create(:user) }
+
+    before do
+      create(:expense_record, user: user)
+    end
+
+    it "最新の家計簿データのis_disabledがtrueになる。" do
+      usecase.perform
+      expect(user.expense_records.last.is_disabled).to be_truthy
+    end
+  end
+end
+

--- a/spec/usecases/soft_delete_latest_expense_record_spec.rb
+++ b/spec/usecases/soft_delete_latest_expense_record_spec.rb
@@ -6,13 +6,12 @@ RSpec.describe SoftDeleteLatestExpenseRecordUsecase, type: :usecase do
     let(:user) { create(:user) }
 
     before do
-      create(:expense_record, user: user)
+      create(:expense_record, user:)
     end
 
-    it "最新の家計簿データのis_disabledがtrueになる。" do
+    it '最新の家計簿データのis_disabledがtrueになる。' do
       usecase.perform
       expect(user.expense_records.last.is_disabled).to be_truthy
     end
   end
 end
-


### PR DESCRIPTION
支出入力モード、収入入力モードにおいて`とりけし`というメッセージを受け取った場合は、最新の家計簿データを論理削除する処理を走らせる。

---
> [!IMPORTANT]
・need to add migration