### PR TITLE
kaizen show mode

### DIFF
--- a/app/services/message_parser/show_message_parser.rb
+++ b/app/services/message_parser/show_message_parser.rb
@@ -27,7 +27,7 @@ module MessageParser
         return error_message(ERROR_TYPE[:CATEGORY]) if category_not_found?(category)
 
         # '月の合計を返す'
-        GetMonthlyTotalUsecase.perform(user:, period:, category:)
+        GetMonthlyTotalUsecase.new(user:, period:, category:).perform
       end
 
       def error_message(error_type)

--- a/app/usecases/get_monthly_total_usecase.rb
+++ b/app/usecases/get_monthly_total_usecase.rb
@@ -8,18 +8,15 @@ class GetMonthlyTotalUsecase
 
   def perform
     # group機能は未実装なため、一旦user自体の家計簿データの合計を返す。
-    message = ''
 
     case @category
     when nil
-      message = monthly_total_group_by_category_name
+      monthly_total_group_by_category_name
     when '合計'
-      message = monthly_total
+      monthly_total
     else
-      message = monthly_total_of_the_category
+      monthly_total_of_the_category
     end
-
-    message
   end
 
   private
@@ -58,13 +55,13 @@ class GetMonthlyTotalUsecase
 
     # 返却するメッセージの1行目をここで用意
     # 2行目は空行を出力したいため、空文字の要素を置いておく。
-    head_message = ["#{formatted_year_month}の費目別合計", ""]
+    head_message = ["#{formatted_year_month}の費目別合計", '']
 
     # 先頭に表示するメッセージに、各費目ごとのメッセージの配列を合わせて、join
     (head_message + expense_messages).join("\n")
   end
 
   def formatted_year_month
-    @period.begin.strftime("%Y年%m月")
+    @period.begin.strftime('%Y年%m月')
   end
 end

--- a/app/usecases/get_monthly_total_usecase.rb
+++ b/app/usecases/get_monthly_total_usecase.rb
@@ -1,19 +1,24 @@
 class GetMonthlyTotalUsecase
-  class << self
-    def perform(user:, period:, category: nil)
-      # group機能は未実装なため、一旦user自体の家計簿データの合計を返す。
-      total = if category && category != '合計'
-                ExpenseRecord.eager_load(:category)
-                             .active
-                             .expense
-                             .where(user:, transaction_date: period)
-                             .where(categories: { name: category })
-                             .sum(:amount)
-              else
-                # 費目の指定がない場合は、userのExpenseRecordsの合計を返す
-                user.expense_records.active.expense.where(transaction_date: period).sum(:amount)
-              end
-      "#{total}円ナリ"
-    end
+  # category: Categoryレコードのnameか、'合計'が入る。nilの場合もあり。
+  def initialize(user:, period:, category: nil)
+    @user = user
+    @period = period
+    @category = category
+  end
+
+  def perform
+    # group機能は未実装なため、一旦user自体の家計簿データの合計を返す。
+    total = if @category && @category != '合計'
+              ExpenseRecord.eager_load(:category)
+                           .active
+                           .expense
+                           .where(user: @user, transaction_date: @period)
+                           .where(categories: { name: @category })
+                           .sum(:amount)
+            else
+              # 費目の指定がない場合は、userのExpenseRecordsの合計を返す
+              @user.expense_records.active.expense.where(transaction_date: @period).sum(:amount)
+            end
+    "#{total}円ナリ"
   end
 end

--- a/app/usecases/get_monthly_total_usecase.rb
+++ b/app/usecases/get_monthly_total_usecase.rb
@@ -8,17 +8,63 @@ class GetMonthlyTotalUsecase
 
   def perform
     # group機能は未実装なため、一旦user自体の家計簿データの合計を返す。
-    total = if @category && @category != '合計'
-              ExpenseRecord.eager_load(:category)
-                           .active
-                           .expense
-                           .where(user: @user, transaction_date: @period)
-                           .where(categories: { name: @category })
-                           .sum(:amount)
-            else
-              # 費目の指定がない場合は、userのExpenseRecordsの合計を返す
-              @user.expense_records.active.expense.where(transaction_date: @period).sum(:amount)
-            end
-    "#{total}円ナリ"
+    message = ''
+
+    case @category
+    when nil
+      message = monthly_total_group_by_category_name
+    when '合計'
+      message = monthly_total
+    else
+      message = monthly_total_of_the_category
+    end
+
+    message
+  end
+
+  private
+
+  # 費目の指定がない場合は、userのExpenseRecordsの合計を返す
+  def monthly_total
+    total = @user.expense_records.active.expense.where(transaction_date: @period).sum(:amount)
+    "#{formatted_year_month}の#{@category}\n\n#{total}円ナリ"
+  end
+
+  # @categoryの@periodにおける合計金額を返す
+  def monthly_total_of_the_category
+    total = ExpenseRecord.eager_load(:category)
+                         .active
+                         .expense
+                         .where(user: @user, transaction_date: @period)
+                         .where(categories: { name: @category })
+                         .sum(:amount)
+
+    "#{formatted_year_month}の#{@category}\n\n#{total}円ナリ"
+  end
+
+  # @periodにおける費目ごとの合計金額を返す
+  def monthly_total_group_by_category_name
+    expenses_by_category_name = @user.expense_records
+                                     .active
+                                     .expense
+                                     .where(transaction_date: @period)
+                                     .joins(:category)
+                                     .group('categories.name')
+                                     .sum(:amount)
+
+    expense_messages = expenses_by_category_name.map do |category_name, total|
+      "#{category_name}: #{total}円"
+    end
+
+    # 返却するメッセージの1行目をここで用意
+    # 2行目は空行を出力したいため、空文字の要素を置いておく。
+    head_message = ["#{formatted_year_month}の費目別合計", ""]
+
+    # 先頭に表示するメッセージに、各費目ごとのメッセージの配列を合わせて、join
+    (head_message + expense_messages).join("\n")
+  end
+
+  def formatted_year_month
+    @period.begin.strftime("%Y年%m月")
   end
 end

--- a/spec/services/message_parser/show_message_parser_spec.rb
+++ b/spec/services/message_parser/show_message_parser_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe MessageParser::ShowMessageParser do
 
       create(
         :expense_record,
+        amount: 3000,
+        transaction_date: Time.zone.now,
+        user:,
+        category: create(:category, name: '交通費')
+      )
+
+      create(
+        :expense_record,
         amount: 2000,
         transaction_date: 1.month.ago,
         user:,
@@ -37,7 +45,7 @@ RSpec.describe MessageParser::ShowMessageParser do
         let(:message) { '2023-11' }
 
         it "returns 2023/11's total" do
-          expect(result).to eq('3000円ナリ')
+          expect(result).to eq("2023年11月の費目別合計\n\n交際費: 3000円")
         end
       end
 
@@ -46,7 +54,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { "先月\n合計" }
 
           it "returns last month's total" do
-            expect(result).to eq('2000円ナリ')
+            expect(result).to eq("#{1.month.ago.strftime('%Y年%m月')}の合計\n\n2000円ナリ")
           end
         end
 
@@ -54,7 +62,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { '先月' }
 
           it "returns last month's total" do
-            expect(result).to eq('2000円ナリ')
+            expect(result).to eq("#{1.month.ago.strftime('%Y年%m月')}の費目別合計\n\n食費: 2000円")
           end
         end
       end
@@ -65,7 +73,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { "先月\n医療費" }
 
           it 'returns 0 yen' do
-            expect(result).to eq('0円ナリ')
+            expect(result).to eq("#{1.month.ago.strftime('%Y年%m月')}の医療費\n\n0円ナリ")
           end
         end
 
@@ -73,7 +81,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { "先月\n食費" }
 
           it 'returns the total of food for the last month' do
-            expect(result).to eq('2000円ナリ')
+            expect(result).to eq("#{1.month.ago.strftime('%Y年%m月')}の食費\n\n2000円ナリ")
           end
         end
       end
@@ -83,7 +91,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { "今月\n合計" }
 
           it "returns this month's total" do
-            expect(result).to eq('1500円ナリ')
+            expect(result).to eq("#{Time.zone.now.strftime('%Y年%m月')}の合計\n\n4500円ナリ")
           end
         end
 
@@ -91,7 +99,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { '今月' }
 
           it "returns this month's total" do
-            expect(result).to eq('1500円ナリ')
+            expect(result).to eq("#{Time.zone.now.strftime('%Y年%m月')}の費目別合計\n\n交通費: 3000円\n食費: 1500円")
           end
         end
       end
@@ -102,7 +110,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { "今月\n医療費" }
 
           it 'returns 0 yen' do
-            expect(result).to eq('0円ナリ')
+            expect(result).to eq("#{Time.zone.now.strftime('%Y年%m月')}の医療費\n\n0円ナリ")
           end
         end
 
@@ -110,7 +118,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { "今月\n食費" }
 
           it 'returns the total of food for the this month' do
-            expect(result).to eq('1500円ナリ')
+            expect(result).to eq("#{Time.zone.now.strftime('%Y年%m月')}の食費\n\n1500円ナリ")
           end
         end
       end

--- a/spec/usecases/get_monthly_total_usecase_spec.rb
+++ b/spec/usecases/get_monthly_total_usecase_spec.rb
@@ -19,8 +19,18 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
     context 'categoryが未指定の場合' do
       let(:category_name) { nil }
 
-      it '今月の合計金額が返される' do
-        expect(usecase).to eq('1500円ナリ')
+      before do
+        create(
+          :expense_record,
+          amount: 3800,
+          transaction_date: Time.zone.now,
+          user:,
+          category: create(:category, name: '医療費')
+        )
+      end
+
+      it '今月の費目ごとの合計金額が返される' do
+        expect(usecase).to eq("#{Time.zone.now.strftime('%Y年%m月')}の費目別合計\n\n医療費: 3800円\n食費: 1500円")
       end
     end
 
@@ -28,12 +38,12 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
       let(:category_name) { '合計' }
 
       it '今月の合計金額が返される' do
-        expect(usecase).to eq('1500円ナリ')
+        expect(usecase).to eq("#{Time.zone.now.strftime('%Y年%m月')}の合計\n\n1500円ナリ")
       end
     end
 
     context '論理削除されているレコードが存在する場合' do
-      let(:category_name) { nil }
+      let(:category_name) { '合計' }
 
       before do
         create(
@@ -49,7 +59,7 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
       it '論理削除済みの家計簿データの分は合計に加算されない' do
         # このcontextで追加したexpense_recordの1000円分は加算されないので、
         # 合計は1500円になる。
-        expect(usecase).to eq('1500円ナリ')
+        expect(usecase).to eq("#{Time.zone.now.strftime('%Y年%m月')}の合計\n\n1500円ナリ")
       end
     end
 
@@ -58,7 +68,7 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
         let(:category_name) { create(:category, name: '食費').name }
 
         it '今月の食費の合計金額が返される' do
-          expect(usecase).to eq('1500円ナリ')
+          expect(usecase).to eq("#{Time.zone.now.strftime('%Y年%m月')}の食費\n\n1500円ナリ")
         end
       end
 
@@ -66,7 +76,7 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
         let(:category_name) { create(:category, name: '医療費').name }
 
         it '0円が返される' do
-          expect(usecase).to eq('0円ナリ')
+          expect(usecase).to eq("#{Time.zone.now.strftime('%Y年%m月')}の医療費\n\n0円ナリ")
         end
       end
 
@@ -85,7 +95,7 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
         end
 
         it '今月の食費の合計金額が返される（論理削除済みの家計簿データ分は加算されない）' do
-          expect(usecase).to eq('1500円ナリ')
+          expect(usecase).to eq("#{Time.zone.now.strftime('%Y年%m月')}の食費\n\n1500円ナリ")
         end
       end
     end

--- a/spec/usecases/get_monthly_total_usecase_spec.rb
+++ b/spec/usecases/get_monthly_total_usecase_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
       end
     end
 
+    context 'categoryが「合計」の場合' do
+      let(:category_name) { '合計' }
+
+      it '今月の合計金額が返される' do
+        expect(usecase).to eq('1500円ナリ')
+      end
+    end
+
     context '論理削除されているレコードが存在する場合' do
       let(:category_name) { nil }
 

--- a/spec/usecases/get_monthly_total_usecase_spec.rb
+++ b/spec/usecases/get_monthly_total_usecase_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
   describe 'perform' do
-    let(:usecase) { described_class.perform(user:, period:, category: category_name) }
+    let(:usecase) { described_class.new(user:, period:, category: category_name).perform }
     let(:user) { create(:user) }
     let(:period) { Time.zone.now.beginning_of_month..Time.zone.now.end_of_day }
 


### PR DESCRIPTION
## 対応前

これまで家計簿データの「確認」モードでは、

```
今月
```

または、

```
今月
合計
```
と入力すると、今月の合計金額を「OO円ナリ」という形で返していた。

## 対応後
```
今月
```
と入力した場合は、
```
2024年02月の費目別合計

食費: 3500円
日用品: 20000円
医療費: 3800円
```
というように、指定された期間の費目別合計を返却するようにした。

```
今月
合計
```

のように指定した場合、

```
2024年02月の合計

OO円ナリ
```
と表示する。

```
今月
食費
```

の場合、

```
2024年02月の食費

OO円ナリ
```

のように表示するように、改善