### PR TITLE
Return Input Template Message

### DIFF
--- a/spec/services/message_parser/input_message_parser_spec.rb
+++ b/spec/services/message_parser/input_message_parser_spec.rb
@@ -195,6 +195,22 @@ RSpec.describe MessageParser::InputMessageParser do
         end
       end
 
+      context '入力テンプレートをリクエストする場合' do
+        let(:message) { 'テンプレ' }
+        let(:response_message) do
+          <<~MESSAGE
+            食費
+            1000
+            ラーメン
+            #{Time.zone.today.strftime('%Y-%m-%d')}
+          MESSAGE
+        end
+
+        it '入力テンプレートが返却される' do
+          expect(result).to eq(response_message.chomp)
+        end
+      end
+
       context 'when expense_input message is invalid' do
         context 'when category is empty' do
           let(:message) { '' }
@@ -354,6 +370,22 @@ RSpec.describe MessageParser::InputMessageParser do
         end
 
         it 'とりけし成功のメッセージが返却される' do
+          expect(result).to eq(response_message.chomp)
+        end
+      end
+
+      context '入力テンプレートをリクエストする場合' do
+        let(:message) { 'テンプレ' }
+        let(:response_message) do
+          <<~MESSAGE
+            食費
+            1000
+            ラーメン
+            #{Time.zone.today.strftime('%Y-%m-%d')}
+          MESSAGE
+        end
+
+        it '入力テンプレートが返却される' do
           expect(result).to eq(response_message.chomp)
         end
       end


### PR DESCRIPTION
issue_link: https://github.com/yuseipen0716/kakeibo_on_rails/issues/25

機能改善

支出データ入力の際に入力する項目のテンプレートを返す機能を追加する。

```
てんぷれ

↓

食費
1000
ラーメン
2024-06-04
```