### PR TITLE
今までに入力した費目リストを確認できるようにする。

### DIFF
--- a/app/usecases/list_category_name_usecase.rb
+++ b/app/usecases/list_category_name_usecase.rb
@@ -1,0 +1,21 @@
+class ListCategoryNameUsecase
+  def initialize(user)
+    @user = user
+  end
+
+  # userのtalk_modeに応じて、これまで使用したことのある費目を返す
+  def perform
+    records = expense_or_income_records
+    return [] if records.blank?
+
+    category_ids = records.pluck(:category_id)
+    Category.where(id: category_ids)
+  end
+
+  private
+
+  def expense_or_income_records
+    records = ExpenseRecord.active
+    @user.talk_mode == 'income_input_mode' ? records.income : records.expense
+  end
+end

--- a/app/usecases/list_category_name_usecase.rb
+++ b/app/usecases/list_category_name_usecase.rb
@@ -8,8 +8,8 @@ class ListCategoryNameUsecase
     records = expense_or_income_records
     return [] if records.blank?
 
-    category_ids = records.pluck(:category_id)
-    Category.where(id: category_ids)
+    category_ids = records.pluck(:category_id).uniq
+    Category.where(id: category_ids).pluck(:name)
   end
 
   private

--- a/spec/services/message_parser/input_message_parser_spec.rb
+++ b/spec/services/message_parser/input_message_parser_spec.rb
@@ -211,6 +211,48 @@ RSpec.describe MessageParser::InputMessageParser do
         end
       end
 
+      context '費目リストを確認する場合' do
+        let(:message) { '費目' }
+
+        context 'when expense record is empty' do
+          let(:response_message) { '表示できる費目が存在しません。' }
+
+          it 'returns empty message' do
+            expect(result).to eq(response_message)
+          end
+        end
+
+        context 'when expense record exists' do
+          before do
+            create(
+              :expense_record,
+              expense_type: :expense,
+              category: create(:category, name: '食費'),
+              user:
+            )
+            create(
+              :expense_record,
+              expense_type: :expense,
+              category: create(:category, name: '書籍'),
+              user:
+            )
+          end
+
+          let(:response_message) do
+            <<~MESSAGE
+              これまでに使用したことのある費目
+
+              食費
+              書籍
+            MESSAGE
+          end
+
+          it 'これまでに使用したことのある費目名が返却される' do
+            expect(result).to eq(response_message.chomp)
+          end
+        end
+      end
+
       context 'when expense_input message is invalid' do
         context 'when category is empty' do
           let(:message) { '' }
@@ -387,6 +429,48 @@ RSpec.describe MessageParser::InputMessageParser do
 
         it '入力テンプレートが返却される' do
           expect(result).to eq(response_message.chomp)
+        end
+      end
+
+      context '費目リストを確認する場合' do
+        let(:message) { '費目' }
+
+        context 'when expense record is empty' do
+          let(:response_message) { '表示できる費目が存在しません。' }
+
+          it 'returns empty message' do
+            expect(result).to eq(response_message)
+          end
+        end
+
+        context 'when expense record exists' do
+          before do
+            create(
+              :expense_record,
+              expense_type: :income,
+              category: create(:category, name: '給与'),
+              user:
+            )
+            create(
+              :expense_record,
+              expense_type: :income,
+              category: create(:category, name: '贈与'),
+              user:
+            )
+          end
+
+          let(:response_message) do
+            <<~MESSAGE
+              これまでに使用したことのある費目
+
+              給与
+              贈与
+            MESSAGE
+          end
+
+          it 'これまでに使用したことのある費目名が返却される' do
+            expect(result).to eq(response_message.chomp)
+          end
         end
       end
 

--- a/spec/usecases/list_category_name_usecase_spec.rb
+++ b/spec/usecases/list_category_name_usecase_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe ListCategoryNameUsecase, type: :usecase do
+  describe '#perform' do
+    let(:usecase) { described_class.new(user).perform }
+    let(:user) { create(:user, talk_mode: current_talk_mode) }
+
+    context 'when talk_mode is expense' do
+      let(:current_talk_mode) { :expense_input_mode }
+
+      context 'when record is empty' do
+        it 'returns []' do
+          expect(usecase).to eq([])
+        end
+      end
+
+      context 'when expense_record exists' do
+        before do
+          create(
+            :expense_record,
+            expense_type: :expense,
+            category: create(:category, name: '食費'),
+            user:
+          )
+        end
+
+        it 'returns ActiveRecord::Relation object' do
+          expect(usecase).to be_a(ActiveRecord::Relation)
+        end
+
+        it 'returns Category records' do
+          expect(usecase.last).to be_a(Category)
+        end
+
+        it 'returns category that name 食費' do
+          expect(usecase.last.name).to eq('食費')
+        end
+      end
+    end
+
+    context 'when talk_mode is expense' do
+      let(:current_talk_mode) { :income_input_mode }
+
+      context 'when record is empty' do
+        it 'returns []' do
+          expect(usecase).to eq([])
+        end
+      end
+
+      context 'when income_record exists' do
+        before do
+          create(
+            :expense_record,
+            expense_type: :income,
+            category: create(:category, name: '給与'),
+            user:
+          )
+        end
+
+        it 'returns ActiveRecord::Relation object' do
+          expect(usecase).to be_a(ActiveRecord::Relation)
+        end
+
+        it 'returns Category records' do
+          expect(usecase.last).to be_a(Category)
+        end
+
+        it 'returns category that name 食費' do
+          expect(usecase.last.name).to eq('給与')
+        end
+      end
+    end
+  end
+end

--- a/spec/usecases/list_category_name_usecase_spec.rb
+++ b/spec/usecases/list_category_name_usecase_spec.rb
@@ -24,16 +24,8 @@ RSpec.describe ListCategoryNameUsecase, type: :usecase do
           )
         end
 
-        it 'returns ActiveRecord::Relation object' do
-          expect(usecase).to be_a(ActiveRecord::Relation)
-        end
-
-        it 'returns Category records' do
-          expect(usecase.last).to be_a(Category)
-        end
-
-        it 'returns category that name 食費' do
-          expect(usecase.last.name).to eq('食費')
+        it 'returns category name' do
+          expect(usecase).to eq(['食費'])
         end
       end
     end
@@ -57,16 +49,8 @@ RSpec.describe ListCategoryNameUsecase, type: :usecase do
           )
         end
 
-        it 'returns ActiveRecord::Relation object' do
-          expect(usecase).to be_a(ActiveRecord::Relation)
-        end
-
-        it 'returns Category records' do
-          expect(usecase.last).to be_a(Category)
-        end
-
-        it 'returns category that name 食費' do
-          expect(usecase.last.name).to eq('給与')
+        it 'returns category name' do
+          expect(usecase).to eq(['給与'])
         end
       end
     end


### PR DESCRIPTION
https://github.com/yuseipen0716/kakeibo_on_rails/issues/28

## 対応内容
これまでに入力したことのある費目のリストを返すreply messageを実装。

### 仕様
対象

→ 支出入力モードなら、これまでに入力したことがある支出データの費目リスト（論理削除したデータの費目は取得しない）

→ 収入入力モードなら、これまでに入力したことがある収入データの費目リスト（論理削除したデータの費目は取得しない）

該当する費目リストが取得できない場合は、「ないよ」的なメッセージを返す