### PR TITLE
[bugfix]費目リストは自分が入力したものだけ返す.

### DIFF
--- a/app/usecases/list_category_name_usecase.rb
+++ b/app/usecases/list_category_name_usecase.rb
@@ -15,7 +15,8 @@ class ListCategoryNameUsecase
   private
 
   def expense_or_income_records
-    records = ExpenseRecord.active
+    # 直近5か月で入力した費目のみ取得するようにしてみる。
+    records = ExpenseRecord.active.where(user_id: @user.id, created_at: 5.months.ago..)
     @user.talk_mode == 'income_input_mode' ? records.income : records.expense
   end
 end

--- a/spec/usecases/list_category_name_usecase_spec.rb
+++ b/spec/usecases/list_category_name_usecase_spec.rb
@@ -28,6 +28,27 @@ RSpec.describe ListCategoryNameUsecase, type: :usecase do
           expect(usecase).to eq(['食費'])
         end
       end
+
+      context "when other user's expense records exists" do
+        before do
+          create(
+            :expense_record,
+            expense_type: :expense,
+            category: create(:category, name: '食費'),
+            user:
+          )
+          create(
+            :expense_record,
+            expense_type: :expense,
+            category: create(:category, name: '書籍'),
+            user: create(:user)
+          )
+        end
+
+        it 'returns category name only own records' do
+          expect(usecase).to eq(['食費'])
+        end
+      end
     end
 
     context 'when talk_mode is expense' do
@@ -50,6 +71,27 @@ RSpec.describe ListCategoryNameUsecase, type: :usecase do
         end
 
         it 'returns category name' do
+          expect(usecase).to eq(['給与'])
+        end
+      end
+
+      context "when other user's income records exists" do
+        before do
+          create(
+            :expense_record,
+            expense_type: :income,
+            category: create(:category, name: '給与'),
+            user:
+          )
+          create(
+            :expense_record,
+            expense_type: :expense,
+            category: create(:category, name: '贈与'),
+            user: create(:user)
+          )
+        end
+
+        it 'returns category name only own records' do
           expect(usecase).to eq(['給与'])
         end
       end


### PR DESCRIPTION
追加で、直近5か月分の支出・収入データから費目を抽出するようにした。