### PR TITLE
グループ機能 Phase2

### DIFF
--- a/app/services/message_handler/group_message_handler.rb
+++ b/app/services/message_handler/group_message_handler.rb
@@ -41,8 +41,8 @@ module MessageHandler
         validation_error = validate_group_creation(user, group_name)
         return validation_error if validation_error
 
-        # TODO: グループ作成処理を実装予定
-        "グループ作成処理（未実装）"
+        # グループ作成処理
+        create_group_for_user(user, group_name)
       end
 
       def handle_group_joining_mode(_user, _message)
@@ -85,6 +85,23 @@ module MessageHandler
         end
 
         nil
+      end
+
+      def create_group_for_user(user, group_name)
+        ActiveRecord::Base.transaction do
+          group = Group.create!(name: group_name)
+          user.update!(group: group, talk_mode: :default_mode)
+          group_creation_success_message(group)
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        "グループの作成に失敗しました。#{e.message}"
+      end
+
+      def group_creation_success_message(group)
+        message = "グループを作成しました。\n\n"
+        message << "グループ名: #{group.name}\n"
+        message << "参加メンバー: #{group.users.count}人"
+        message
       end
     end
   end

--- a/app/services/message_handler/group_message_handler.rb
+++ b/app/services/message_handler/group_message_handler.rb
@@ -101,6 +101,8 @@ module MessageHandler
         message = "グループを作成しました。\n\n"
         message << "グループ名: #{group.name}\n"
         message << "参加メンバー: #{group.users.count}人"
+
+        # TODO: 今後、家計簿データの確認モードで同じグループの家計簿データの合計を出す機能などを実装予定
         message
       end
     end

--- a/app/services/message_handler/group_message_handler.rb
+++ b/app/services/message_handler/group_message_handler.rb
@@ -34,7 +34,14 @@ module MessageHandler
         end
       end
 
-      def handle_group_creating_mode(_user, _message)
+      def handle_group_creating_mode(user, message)
+        group_name = message.strip
+
+        # バリデーション
+        validation_error = validate_group_creation(user, group_name)
+        return validation_error if validation_error
+
+        # TODO: グループ作成処理を実装予定
         "グループ作成処理（未実装）"
       end
 
@@ -65,6 +72,19 @@ module MessageHandler
         message << "参加したいグループ名を入力してください"
 
         message.chomp
+      end
+
+      def validate_group_creation(user, group_name)
+        return "グループ名を入力してください。" if group_name.blank?
+        return "グループ名は10文字以内で入力してください。" if group_name.length > 10
+        return "そのグループ名は既に使用されています。別のグループ名で作成してください。" if Group.exists?(name: group_name)
+
+        if user.group.present?
+          user.update(talk_mode: :default_mode)
+          return "既にグループに参加しています。"
+        end
+
+        nil
       end
     end
   end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: groups
+#
+#  id         :integer          not null, primary key
+#  name       :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+FactoryBot.define do
+  factory :group do
+    name { "テストグループ" }
+  end
+end

--- a/spec/services/message_handler/group_message_handler_spec.rb
+++ b/spec/services/message_handler/group_message_handler_spec.rb
@@ -72,6 +72,18 @@ RSpec.describe MessageHandler::GroupMessageHandler, type: :service do
           expect(result).to include("グループ名: 新しいグループ")
           expect(result).to include("参加メンバー: 1人")
         end
+
+        it "handles group name with special characters" do
+          result = MessageHandler::GroupMessageHandler.perform(user, "家族😊💰")
+          expect(result).to include("グループを作成しました。")
+          expect(result).to include("グループ名: 家族😊💰")
+        end
+
+        it "handles exactly 10 character group name" do
+          result = MessageHandler::GroupMessageHandler.perform(user, "1234567890")
+          expect(result).to include("グループを作成しました。")
+          expect(result).to include("グループ名: 1234567890")
+        end
       end
 
       context "with validation errors" do
@@ -87,6 +99,11 @@ RSpec.describe MessageHandler::GroupMessageHandler, type: :service do
 
         it "returns error message for group name longer than 10 characters" do
           result = MessageHandler::GroupMessageHandler.perform(user, "12345678901")
+          expect(result).to eq("グループ名は10文字以内で入力してください。")
+        end
+
+        it "returns error message for multi-byte characters exceeding 10 characters" do
+          result = MessageHandler::GroupMessageHandler.perform(user, "あいうえおかきくけこさ") # 11文字
           expect(result).to eq("グループ名は10文字以内で入力してください。")
         end
 


### PR DESCRIPTION
  実装した機能

  ✅ 完全なグループ作成フロー
  - 「グループ作成・参加」→「作成」→グループ名入力→グループ作成完了

  ✅ 包括的なバリデーション
  - 空文字・空白文字チェック
  - 10文字以内の長さチェック（マルチバイト対応）
  - グループ名重複チェック
  - ユーザーの既参加チェック

  ✅ robust なエラーハンドリング
  - データベースエラーのキャッチ
  - 適切なエラーメッセージ表示
  - talk_mode の適切な管理

  ✅ 高品質なテストカバレッジ
  - 20テストケース（全通過）
  - 正常系・異常系・エッジケースを網羅
  - 特殊文字・絵文字対応のテスト

  現在の動作フロー

  ユーザー: "グループ作成・参加"
  → group_mode: "作成" or "参加" の案内

  ユーザー: "作成"
  → group_creating_mode: "グループ名を入力してください"

  ユーザー: "家族"
  → バリデーション → グループ作成 → default_mode
  → "グループを作成しました。\n\nグループ名: 家族\n参加メンバー: 1人"