### PR TITLE
確認モードでグループの合計値も表示する

### DIFF
--- a/app/services/message_handler/show_message_handler.rb
+++ b/app/services/message_handler/show_message_handler.rb
@@ -39,6 +39,8 @@ module MessageHandler
           ------------
 
           のように入力してください。
+
+          ※「今月」のみ入力すると、個人とグループ（所属している場合）の費目別合計が表示されます。
         SHOW
 
         message << first_message

--- a/spec/services/message_handler/core_handler_spec.rb
+++ b/spec/services/message_handler/core_handler_spec.rb
@@ -103,6 +103,8 @@ RSpec.describe MessageHandler::CoreHandler do
           ------------
 
           のように入力してください。
+
+          ※「今月」のみ入力すると、個人とグループ（所属している場合）の費目別合計が表示されます。
         RESPONSE
       end
 

--- a/spec/services/message_parser/show_message_parser_spec.rb
+++ b/spec/services/message_parser/show_message_parser_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe MessageParser::ShowMessageParser do
         let(:message) { "2023-11" }
 
         it "returns 2023/11's total" do
-          expect(result).to eq("2023年11月の費目別合計\n\n交際費: 3000円")
+          expect(result).to eq("2023年11月の費目別合計\n\n<個人>\n交際費: 3000円")
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { "先月" }
 
           it "returns last month's total" do
-            expect(result).to eq("#{1.month.ago.strftime("%Y年%m月")}の費目別合計\n\n食費: 2000円")
+            expect(result).to eq("#{1.month.ago.strftime("%Y年%m月")}の費目別合計\n\n<個人>\n食費: 2000円")
           end
         end
       end
@@ -99,7 +99,7 @@ RSpec.describe MessageParser::ShowMessageParser do
           let(:message) { "今月" }
 
           it "returns this month's total" do
-            expect(result).to eq("#{Time.zone.now.strftime("%Y年%m月")}の費目別合計\n\n交通費: 3000円\n食費: 1500円")
+            expect(result).to eq("#{Time.zone.now.strftime("%Y年%m月")}の費目別合計\n\n<個人>\n交通費: 3000円\n食費: 1500円")
           end
         end
       end

--- a/spec/usecases/get_monthly_total_usecase_spec.rb
+++ b/spec/usecases/get_monthly_total_usecase_spec.rb
@@ -29,8 +29,9 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
         )
       end
 
-      it "今月の費目ごとの合計金額が返される" do
-        expect(usecase).to eq("#{Time.zone.now.strftime("%Y年%m月")}の費目別合計\n\n医療費: 3800円\n食費: 1500円")
+      it "今月の費目ごとの合計金額が個人とグループ（所属していない場合は個人のみ）で返される" do
+        expected_message = "#{Time.zone.now.strftime("%Y年%m月")}の費目別合計\n\n<個人>\n医療費: 3800円\n食費: 1500円"
+        expect(usecase).to eq(expected_message)
       end
     end
 
@@ -97,6 +98,61 @@ RSpec.describe GetMonthlyTotalUsecase, type: :usecase do
         it "今月の食費の合計金額が返される（論理削除済みの家計簿データ分は加算されない）" do
           expect(usecase).to eq("#{Time.zone.now.strftime("%Y年%m月")}の食費\n\n1500円ナリ")
         end
+      end
+    end
+
+    context "グループ機能のテスト" do
+      let(:category_name) { nil }
+      let(:group) { create(:group) }
+      let(:group_member) { create(:user, group:) }
+
+      before do
+        user.update!(group:)
+
+        # グループメンバーの支出データを作成
+        create(
+          :expense_record,
+          amount: 2000,
+          transaction_date: Time.zone.now,
+          user: group_member,
+          category: create(:category, name: "食費")
+        )
+        create(
+          :expense_record,
+          amount: 1000,
+          transaction_date: Time.zone.now,
+          user: group_member,
+          category: create(:category, name: "交通費")
+        )
+      end
+
+      it "個人とグループの費目別合計が返される" do
+        expected_message = "#{Time.zone.now.strftime("%Y年%m月")}の費目別合計\n\n<個人>\n食費: 1500円\n\n<グループ>\n交通費: 1000円\n食費: 3500円"
+        expect(usecase).to eq(expected_message)
+      end
+    end
+
+    context "グループに所属しているが個人データがない場合" do
+      let(:category_name) { nil }
+      let(:group) { create(:group) }
+      let(:user_without_data) { create(:user, group:) }
+      let(:usecase) { described_class.new(user: user_without_data, period:, category: category_name).perform }
+
+      before do
+        # 同じグループに所属するメンバーを作成してデータを追加
+        user.update!(group:)
+        create(
+          :expense_record,
+          amount: 2000,
+          transaction_date: Time.zone.now,
+          user:,
+          category: create(:category, name: "食費")
+        )
+      end
+
+      it "個人はデータなし、グループの合計が表示される" do
+        expected_message = "#{Time.zone.now.strftime("%Y年%m月")}の費目別合計\n\n<個人>\nデータなし\n\n<グループ>\n食費: 3500円"
+        expect(usecase).to eq(expected_message)
       end
     end
   end


### PR DESCRIPTION
● Summary

  show_modeでグループメンバーの支出合計を表示する機能を実装しました。
  「今月」のみ入力した場合に、個人とグループ（所属している場合）の費目別合計を同時に表示します。

  Changes

  🎯 新機能

  - グループ集計表示: 個人とグループの費目別合計を<個人>と<グループ>セクションに分けて表示
  - 既存機能維持: 従来のショートハンド機能（今月のみ入力）との完全互換性を保持
  - 柔軟な表示: グループに所属していない場合は個人分のみ、データがない場合は「データなし」を表示

  📝 出力例

  2025年07月の費目別合計

  <個人>
  食費: 1500円

  <グループ>
  交通費: 1000円
  食費: 3500円

  🔧 技術的変更

  - GetMonthlyTotalUsecaseにグループ集計ロジックを追加
  - 費目名のアルファベット順ソートを実装
  - ShowMessageHandlerのヘルプメッセージを更新

  Test plan

  - 個人のみのデータ表示テスト
  - グループ集計機能のテスト
  - 個人データなし、グループデータありのテスト
  - 既存機能（カテゴリ指定、合計表示）の回帰テスト
  - Rubocopによるコード品質チェック
  - 全テストケース通過確認
